### PR TITLE
chore: Minor change to use https in the github url in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "jbs"
 description = "Toolkit for Rapid Application Development"
-homepage = "http://github.com/bfren/jeebs-rs"
-documentation = "http://github.com/bfren/jeebs-rs"
-repository = "http://github.com/bfren/jeebs-rs"
+homepage = "https://github.com/bfren/jeebs-rs"
+documentation = "https://github.com/bfren/jeebs-rs"
+repository = "https://github.com/bfren/jeebs-rs"
 readme = "README.md"
 version = "0.1.0-beta.23120801"
 edition = "2021"


### PR DESCRIPTION
GitHub redirects to the address with https anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/97